### PR TITLE
Fee value has to be decimal (15,2)

### DIFF
--- a/lib/fiscalizer/serializers/invoice.rb
+++ b/lib/fiscalizer/serializers/invoice.rb
@@ -57,7 +57,7 @@ class Fiscalizer
           object.fees.each do |fee|
             xml['tns'].Naknada do
               xml['tns'].NazivN fee.name
-              xml['tns'].IznosN fee.value
+              xml['tns'].IznosN fee.value_str
             end
           end
         end


### PR DESCRIPTION
When fiscalising Invoice with Fee
Fiscalizer::Fee.new(name: 'Povratna naknada', value: 0.5)

Response from Porezna is:
Poruka nije u skladu s XML shemom :  cvc-simple-type 1: element {http://www.apis-it.hr/fin/2012/types/f73}IznosN value '0.5' is not a valid instance of type {http://www.apis-it.hr/fin/2012/types/f73}IznosType 🙄

I noticed we have value_str in Fiscalizer:Fee so we can just use that in the serializer?